### PR TITLE
Fix default locale for CMSStore

### DIFF
--- a/src/main/scala/com/liftweb/lib/CMSStore.scala
+++ b/src/main/scala/com/liftweb/lib/CMSStore.scala
@@ -197,7 +197,7 @@ object CMSStore {
   /**
    * What's the default locale
    */
-  lazy val defaultLocale = Locale.getDefault
+  lazy val defaultLocale = Locale.US
 
   def localeFor(in: String): Box[Locale] = 
     Locale.getAvailableLocales().filter(_.toString == in).headOption


### PR DESCRIPTION
We should use same locale for CMSStore and CMS::calcLocale().
Otherwise parsed templates are not found on the systems with non-US default locale.
