### PR TITLE
Integrating the FoBo module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,11 +17,14 @@ resolvers += "Scala" at "https://oss.sonatype.org/content/groups/scala-tools/"
 
 resolvers += "Java.net Maven2 Repository" at "http://download.java.net/maven/2/"
 
+resolvers += "Media4u101 SNAPSHOT Repository" at "http://www.media4u101.se:8081/nexus/content/repositories/snapshots/"
+
 libraryDependencies ++= {
   val liftVersion = "2.5-SNAPSHOT"
   Seq(
     "net.liftweb" %% "lift-webkit" % liftVersion % "compile",
-    "net.liftweb" %% "lift-mapper" % "2.5-SNAPSHOT" % "compile"
+    "net.liftweb" %% "lift-mapper" % "2.5-SNAPSHOT" % "compile",
+    "net.liftmodules" %% "fobo" % (liftVersion+"-0.5.0-SNAPSHOT")
     )
 }
 

--- a/src/main/scala/bootstrap/liftweb/Boot.scala
+++ b/src/main/scala/bootstrap/liftweb/Boot.scala
@@ -12,6 +12,8 @@ import Loc._
 import org.hoisted._
 import lib._
 
+import net.liftmodules.FoBo
+
 /**
  * A class that's instantiated early and run.  It allows the application
  * to modify lift's environment
@@ -39,6 +41,11 @@ class Boot {
 
     // where to search snippet
     LiftRules.addToPackages("org.hoisted")
+    
+    FoBo.InitParam.JQuery=FoBo.JQuery171  
+    FoBo.InitParam.ToolKit=FoBo.Bootstrap204
+    FoBo.InitParam.ToolKit=FoBo.PrettifyJun2011
+    FoBo.init()
     
     CMSStore.defaultHost
 


### PR DESCRIPTION
Small patch that will enable the FoBo module with bootstrap v2.0.4, google prettify, jquery v1.7.1 set as initparameters in boot.scala.
