### PR TITLE
Style-able vertical and horizontal menu section dividers. 

### DIFF
--- a/src/main/scala/org/hoisted/lib/MetadataKey.scala
+++ b/src/main/scala/org/hoisted/lib/MetadataKey.scala
@@ -245,6 +245,11 @@ case object DateFormatKey extends MetadataKey {
   def key = "date-format"
 }
 
+case object MenuDividerKey extends MetadataKey {
+  def global = false
+  def key = "menu-divider"
+}
+
 object MetadataKey {
   lazy val knownKeys = List(OrderKey, OutputPathKey, TemplateURLKey, SiteNameKey, LinkKey,
     TitleKey, TemplateKey, ServeKey,
@@ -254,7 +259,7 @@ object MetadataKey {
     HasBlogKey, TagsKey, AliasKey, HTagBodyKey,
     ValidFromKey, ValidToKey, EventKey, PostKey, LayoutKey, RedirectKey,
   MenuLocGroupKey, MenuIconKey, MenuIconPlacementKey,
-  ShowIfKey, HideIfKey, DateFormatKey)
+  ShowIfKey, HideIfKey, DateFormatKey, MenuDividerKey)
 
   def apply(s: String): MetadataKey = {
     val (_s, top) = if (s.startsWith("!")) (s.substring(1), true) else (s, false)


### PR DESCRIPTION
Hi David, 

I have implemented a menu:divider that will make it possible to have extra style-able li tags in the menu by specifying a menu-divider tag and its value pointing to the class name used for styling. 
This would be a great thing to have to, for example be able to divide a drop down menu in sections but also for vertical dividers in the navbar itself.  
