### PR TITLE
Add asciidoc support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbtassembly.AssemblyPlugin.autoImport._
 //Project Information
 name := "Hoisted"
 
-scalaVersion := "2.11.6"
+scalaVersion := "2.12.1"
 
 scalacOptions += "-deprecation"
 
@@ -31,7 +31,7 @@ version := "0.3-SNAPSHOT"
 // crossScalaVersions in ThisBuild    := Seq("2.9.2", "2.10.0") // "2.9.1-1", "2.9.1", "2.9.0-1", "2.9.0")
 
 libraryDependencies ++= {
-  val liftVersion = "3.0-SNAPSHOT"
+  val liftVersion = "3.0.1"
   Seq(
     "net.liftweb" %% "lift-webkit" % liftVersion % "compile",
     "net.liftweb" %% "lift-common" % liftVersion % "compile",
@@ -47,7 +47,9 @@ libraryDependencies ++= {
     "ch.qos.logback" % "logback-classic" % "1.0.6" % "compile" ,
     "org.eclipse.jgit" % "org.eclipse.jgit" % "1.3.0.201202151440-r",
     "io.netty" % "netty" % "3.5.10.Final",
-    "org.specs2" %% "specs2" % "2.3.11" % "test"
+    ("org.asciidoctor"     % "asciidoctorj" % "1.5.4.1").
+      exclude("org.jruby", "jruby-complete"),
+    "org.jruby" % "jruby-complete" % "1.7.26" % "provided"
   )
 }
 

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.13.0")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 

--- a/src/main/scala/org/hoisted/lib/AsciidocParser.scala
+++ b/src/main/scala/org/hoisted/lib/AsciidocParser.scala
@@ -1,0 +1,123 @@
+package org.hoisted.lib
+
+import scala.collection.JavaConverters._
+import scala.xml.{Elem, NodeSeq}
+
+import net.liftweb._
+  import common._
+  import util.{Helpers}
+
+import org.asciidoctor._
+
+/**
+ * Created with IntelliJ IDEA.
+ * User: dpp
+ * Date: 6/8/12
+ * Time: 11:56 AM
+ * To change this template use File | Settings | File Templates.
+ */
+
+
+object AsciidocParser extends Loggable {
+  lazy val matchMetadata = """(?m)\A(:?[ \t]*\n)?(?:-{3,}+\n)?(^([a-zA-Z0-9 _\-]+)[=:]([^\n]*)\n+(:?[ \t]*\n)?)+(:?-{3,}+\n)?""".r
+
+  lazy val topMetadata = """(?m)^([^:]+):[ \t]*(.*)$""".r
+
+  lazy val topYamlStuff = """(?m)(?:^\w$)*^-{3,}$((?:.|\n)*)^-{3,}$""".r
+
+  lazy val lineSplit = """(?m)^(.*)$""".r
+
+  lazy val linkDefs = """(?m)^\p{Space}{0,3}\[([^:]+)[=:](?:[ ]*)(.+)\]:""".r
+
+  lazy val hasYaml = """(?s)(?m)^[yY][aA][mM][lL][ \t]*\{[ \t]*$(.*?)^\}[ \t]*[yY][Aa][mM][Ll][ \t]*$""".r
+  lazy val htmlHasYaml = """(?s)(?m)\A(:?[ \t]*\n)*^[yY][aA][mM][lL][ \t]*\{[ \t]*$(.*?)^\}[ \t]*[yY][Aa][mM][Ll][ \t]*$""".r
+
+  def childrenOfBody(in: NodeSeq): NodeSeq = {
+    (in \ "body").toList match {
+      case Nil => in
+      case xs => xs.collect {
+        case e: Elem => e
+      }.flatMap(_.child)
+    }
+  }
+
+  def readTopMetadata(in: String, markdownFormat: Boolean): (String, MetadataValue, Any) = {
+    topYamlStuff.findFirstMatchIn(in) match {
+      case Some(matcher) =>
+        val yaml = matcher.group(1)
+        YamlUtil.parse(yaml).map {
+          case (meta, json) =>
+            (topYamlStuff.replaceFirstIn(in, ""), meta, json)
+        }.openOr(in, NullMetadataValue, null)
+
+      case _ =>
+        val yamlRegex = if (markdownFormat) hasYaml else htmlHasYaml
+
+        val pairs: List[(MetadataValue, Any)] =
+          for {
+            thing <- yamlRegex.findAllIn(in).matchData.toList
+            yamlStr = thing.group(1)
+            yaml <- YamlUtil.parse(yamlStr)
+          } yield yaml
+
+        val jsMeta = pairs match {
+          case (_, ret) :: Nil => ret
+          case _ => null
+        }
+
+        val (_in, p2) =
+          pairs.map(_._1) match {
+            case Nil =>
+              matchMetadata.findFirstIn(in) match {
+                case Some(data) =>
+                  (matchMetadata.replaceAllIn(in, ""),
+                    List(KeyedMetadataValue.build(lineSplit.findAllIn(data).toList.flatMap(s =>
+                      topMetadata.findAllIn(s).matchData.toList.map(md => (md.group(1).trim, md.group(2).trim))))))
+                case None => (in, List(NullMetadataValue))
+              }
+            case x => (yamlRegex.replaceAllIn(in, ""), x)
+          }
+
+        val pairs2: MetadataValue = if (markdownFormat)
+          KeyedMetadataValue.build(linkDefs.findAllIn(_in).
+            matchData.toList.map(md => (md.group(1).trim, md.group(2).trim)))
+        else NullMetadataValue
+
+        (_in, p2.foldLeft(pairs2)(_ +&+ _), jsMeta)
+    }
+  }
+
+  private lazy val asciidoctor = Asciidoctor.Factory.create()
+  private lazy val asciidoctorAttributes =
+    AttributesBuilder.attributes()
+      .unsetStyleSheet()
+  private lazy val asciidoctorOptions =
+    OptionsBuilder.options()
+      .safe(SafeMode.SAFE)
+      .attributes(asciidoctorAttributes)
+
+  def parse(in: String): Box[(NodeSeq, MetadataValue, Any)] = {
+    asciidoctor.synchronized {
+      for {
+        documentAttributes <- Helpers.tryo(asciidoctor.readDocumentHeader(in).getAttributes)
+        stringMetadata =
+          documentAttributes.asScala.toList.flatMap {
+            case (key, value: String) => Seq((key, value))
+            case (key, other) =>
+              logger.info(s"Found non-string asciidoc metadata value for $key: $other")
+              Seq()
+          }
+        metadata = KeyedMetadataValue.build(stringMetadata)
+        htmlString <- Helpers.tryo(asciidoctor.convert(in, asciidoctorOptions))
+        res = HoistedHtml5.parse(s"<html><head><title>I eat yaks</title></head><body>$htmlString</body></html>")
+        documentBody <- res.map {
+          res => (res \ "body").collect {
+            case e: Elem => e
+          }.flatMap(_.child)
+        }
+      } yield {
+        (documentBody, metadata, documentAttributes)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Bumps Lift to 3.0.1 and Scala to 2.12.1.

Also adds asciidoc support (asciidoctorj's API is pretty stellar, it turns out).

Unfortunately due to JRuby packaging situations, right now this doesn't
work directly with sbt assembly (rather, the result isn't directly runnable
from the assembled JAR). I've excluded the jruby-complete JAR (or rather
marked it provided) and for now execution looks like this:

```bash
> java -cp ~/.ivy2/cache/org.jruby/jruby-complete/bundles/jruby-complete-1.7.26.jar:target/scala-2.12/hoisted.jar org.hoisted.lib.Hoist ../cms_site/site ../cms_site/compiled
```

i.e., you have to set the classpath to include the jruby-complete JAR
followed by the hoisted JAR explicitly, and then specify the main class.
Definitely not as pretty as I'd like, and I'm going to try to figure out
why including JRuby directly in the assembly JAR makes things go boom
boom with `NoClassDefFoundError`s. Any pointers welcome…