### PR TITLE
Mark Me Down: Improvements to markdown and asciidoc metadata support

### DIFF
--- a/src/main/scala/org/hoisted/lib/AsciidocParser.scala
+++ b/src/main/scala/org/hoisted/lib/AsciidocParser.scala
@@ -91,6 +91,7 @@ object AsciidocParser extends Loggable {
   private lazy val asciidoctorAttributes =
     AttributesBuilder.attributes()
       .unsetStyleSheet()
+      .showTitle(true)
   private lazy val asciidoctorOptions =
     OptionsBuilder.options()
       .safe(SafeMode.SAFE)
@@ -107,6 +108,7 @@ object AsciidocParser extends Loggable {
               logger.info(s"Found non-string asciidoc metadata value for $key: $other")
               Seq()
           }
+
         metadata = KeyedMetadataValue.build(stringMetadata)
         htmlString <- Helpers.tryo(asciidoctor.convert(in, asciidoctorOptions))
         res = HoistedHtml5.parse(s"<html><head><title>I eat yaks</title></head><body>$htmlString</body></html>")

--- a/src/main/scala/org/hoisted/lib/BaseSnippets.scala
+++ b/src/main/scala/org/hoisted/lib/BaseSnippets.scala
@@ -186,12 +186,18 @@ object BaseSnippets extends LazyLoggableWithImplicitLogger {
         "data-htag=root [class+]" #> (depthClass + rd) & "a *" #> body & "a [href]" #> ("#"+id) andThen  "* [data-htag]" #> (Empty: Box[String]))).apply(ns)
   }
 
+  private[this] def titleFromParsedFile(file: ParsedFile): NodeSeq = {
+    file.findData(MetadataKey("title")).flatMap(_.asNodeSeq) or
+      file.findData(MetadataKey("sub")).flatMap(_.asNodeSeq) openOr
+      Text(file.fileInfo.name)
+  }
+
   def doSubs(in: NodeSeq): NodeSeq = {
     val info = for {
       tpe <- S.attr("type").toList
       max = S.attr("max").flatMap(asInt).filter(_ > 0) openOr 10
       rec <- env.findByTag("sub", Full(tpe)).take(max)
-      title = rec.findData(MetadataKey("sub")).flatMap(_.asNodeSeq) openOr Text("Happening")
+      title = titleFromParsedFile(rec)
       desc = rec.findData(MetadataKey("desc")).flatMap(_.asNodeSeq)
     } yield (rec, title, desc)
 

--- a/src/main/scala/org/hoisted/lib/MarkdownParser.scala
+++ b/src/main/scala/org/hoisted/lib/MarkdownParser.scala
@@ -97,7 +97,22 @@ object MarkdownParser {
             case e: Elem => e
           }.flatMap(_.child)
         }
-      } yield (info, retPairs, rawJson)
+
+        titleFromHtml = res.map(_ \\ "h1").flatMap(_.headOption).map(_.text)
+      } yield {
+        // Use title from HTML if no other title has been specified.
+        val finalMetadata =
+          (retPairs.map.get(MetadataKey("title")), titleFromHtml) match {
+            case (Some(_), _) =>
+              retPairs
+            case (_, Full(title)) =>
+              retPairs +&+ KeyedMetadataValue(MetadataKey("title"), MetadataValue(title))
+            case _ =>
+              retPairs
+          }
+
+        (info, finalMetadata, rawJson)
+      }
     }
 
   }

--- a/src/main/scala/org/hoisted/lib/MetadataValue.scala
+++ b/src/main/scala/org/hoisted/lib/MetadataValue.scala
@@ -2,7 +2,7 @@ package org.hoisted.lib
 
 import java.util
 
-import xml.NodeSeq
+import xml.{NodeSeq,Text}
 import net.liftweb._
 import common._
 import net.liftweb.util.Helpers
@@ -120,6 +120,7 @@ case object NullMetadataValue extends MetadataValue {
 
 final case class StringMetadataValue(s: String) extends MetadataValue  {
   def asString: Box[String] = Full(s)
+  override def asNodeSeq: Box[NodeSeq] = Full(Text(s))
   lazy val asBoolean: Box[Boolean] = Helpers.asBoolean(s)
   lazy val asDate: Box[DateTime] = DateUtils.parseDate(s.trim)
   lazy val asInt: Box[Int] = Helpers.asInt(s)


### PR DESCRIPTION
We specifically add support for pulling subsection stuff out of
Markdown- and asciidoc-friendly metadata. Until now that relied
on XML-based metadata to be fully implemented correctly.

We also auto-extract titles in Markdown and asciidoc documents
so that you don't have to explicitly specify title metadata if you don't
want to.

This enables Lift site happenings pages to be written entirely in
markdown, for which I will open a PR on https://github.com/lift/cms_site
soonly.