### PR TITLE
Relativistic Speeds: Fix issues with exclude_dir_from_rendering paths + accelerate unrendered file passthroughs

### DIFF
--- a/src/main/scala/org/hoisted/lib/EnvironmentManager.scala
+++ b/src/main/scala/org/hoisted/lib/EnvironmentManager.scala
@@ -341,6 +341,15 @@ class EnvironmentManager() extends LazyLoggableWithImplicitLogger with Factory {
   def computeDate: ParsedFile => DateTime = pf => pf.findData(DateKey).flatMap(_.asDate) or
     (pf.fileInfo.file.map(ff => new DateTime(ff.lastModified()))) openOr new DateTime()
 
+  /**
+   * Given a ParsedFile, return true if the file should be copied in as low-
+   * level a way as possible, vs being written via an input/output stream pair.
+   *
+   * By default, if a file is excluded from rendering (see [[excludeFile]]), it
+   * is copied.
+   */
+  def shouldCopyFile: ParsedFile => Boolean = excludeFile
+
   def shouldWriteFile: ParsedFile => Boolean =
     pf => !pf.neverWrite && {
       pf.findData(ServeKey).flatMap(_.asBoolean) openOr (pf.pathAndSuffix.path match {

--- a/src/main/scala/org/hoisted/lib/ParsedFile.scala
+++ b/src/main/scala/org/hoisted/lib/ParsedFile.scala
@@ -7,6 +7,7 @@ import util._
 import Helpers._
 import scala.xml._
 import java.io._
+import java.nio.file.{Files,StandardCopyOption}
 import org.joda.time.{ DateTime}
 import collection.mutable.ListBuffer
 import org.apache.tika.parser.AutoDetectParser
@@ -349,6 +350,20 @@ sealed trait ParsedFile {
   def uniqueId: String
 
   def writeTo(out: OutputStream): Unit
+
+  def copyTo(out: File): Unit = {
+    val sourcePath =
+      fileInfo.file
+        .openOrThrowException(s"Copying file but no source file was found: ${fileInfo}")
+        .toPath
+
+    Files.copy(
+      sourcePath,
+      out.toPath,
+      StandardCopyOption.REPLACE_EXISTING,
+      StandardCopyOption.COPY_ATTRIBUTES
+    )
+  }
 
   lazy val bytes:Box[Array[Byte]] = {
     Helpers.tryo{

--- a/src/main/scala/org/hoisted/lib/RunHoisted.scala
+++ b/src/main/scala/org/hoisted/lib/RunHoisted.scala
@@ -191,12 +191,17 @@ trait HoistedRenderer extends LazyLoggableWithImplicitLogger with PluginRunner w
         if (env.shouldWriteFile(pf)) {
           val where: File = calcFile(pf)
           where.getParentFile.mkdirs()
-          val out = new FileOutputStream(where)
-          try {
-            pf.writeTo(out)
-          } finally {
-            HoistedUtil.logFailure("Trying to flush " + pf.pathAndSuffix)(out.flush())
-            HoistedUtil.logFailure("Trying to close " + pf.pathAndSuffix)(out.close())
+
+          if (env.shouldCopyFile(pf)) {
+            pf.copyTo(where)
+          } else {
+            val out = new FileOutputStream(where)
+            try {
+              pf.writeTo(out)
+            } finally {
+              HoistedUtil.logFailure("Trying to flush " + pf.pathAndSuffix)(out.flush())
+              HoistedUtil.logFailure("Trying to close " + pf.pathAndSuffix)(out.close())
+            }
           }
           // where.setLastModified(env.computeDate(pf).getMillis)
         }


### PR DESCRIPTION
Two tidbits here… We copy items excluded from rendering directly, and we adjust exclude directory paths relative to the file that declares the path.